### PR TITLE
Load SecureHeaders only in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,7 +63,7 @@ gem 'sidekiq'
 gem 'high_voltage', '~> 3.0.0'
 
 # Security
-gem 'secure_headers'
+gem 'secure_headers', require: false
 
 group :production do
   # Remove this if the app is not hosted on Heroku

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -1,4 +1,8 @@
 # frozen_string_literal: true
 
-# See: https://github.com/twitter/secureheaders
-SecureHeaders::Configuration.default
+if Rails.env.production?
+  require 'secure_headers'
+
+  # See: https://github.com/twitter/secureheaders
+  SecureHeaders::Configuration.default
+end


### PR DESCRIPTION
Have `SecureHeaders` load only in production