### PR TITLE
Include jQuery to make included Bootstrap work

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,9 @@ gem 'airbrake', '~> 6.0', require: false
 # Frontend
 gem 'bootstrap-sass'
 
+# Rails 5.1 doesn't include jQuery by default
+gem 'jquery-rails'
+
 # Job queue
 gem 'sidekiq'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,6 +132,10 @@ GEM
       rack (>= 1.4.5)
     high_voltage (3.0.0)
     i18n (0.8.1)
+    jquery-rails (4.3.1)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
     jsonapi-renderer (0.1.2)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -342,6 +346,7 @@ DEPENDENCIES
   foreman
   heroku-deflater
   high_voltage (~> 3.0.0)
+  jquery-rails
   listen (>= 3.0.5, < 3.2)
   lograge
   memory_profiler
@@ -377,4 +382,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.14.6
+   1.15.0

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,7 +1,7 @@
 // This is a manifest file that'll be compiled into application.js, which will include all the files
 // listed below.
 //
-// Any JavaScript/Coffee file within this directory, lib/assets/javascripts, or any plugin's 
+// Any JavaScript/Coffee file within this directory, lib/assets/javascripts, or any plugin's
 // vendor/assets/javascripts directory can be referenced here using a relative path.
 //
 // It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
@@ -11,6 +11,7 @@
 // about supported directives.
 //
 //= require rails-ujs
+//= require jquery
 //= require turbolinks
 //= require bootstrap-sprockets
 //= require_tree .


### PR DESCRIPTION
Rails 5.1 doesn't include jquery anymore, thus making the enabled bootstrap JS failed to load and throws `jQuery is not defined` in JS console. This PR is bringing the `jQuery` back.

### Notes

- Should we enable and use Bootstrap for the front end by default?