### PR TITLE
Add action cable TODO

### DIFF
--- a/config/cable.yml
+++ b/config/cable.yml
@@ -7,4 +7,5 @@ test:
 production:
   adapter: redis
   url: redis://localhost:6379/1
+  # TODO: Change channel prefix
   channel_prefix: rails_new_production


### PR DESCRIPTION
Add TODO on cable.yml  to avoid channel name conflicts on single redis server