### PR TITLE
Remove extra title tag

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>RailsNew</title>
     <%= csrf_meta_tags %>
 
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>


### PR DESCRIPTION
@citizen428 I noticed this last night. This first title tag takes precedence over whatever you set in `:page_title`. Related: should the app have a default title?