### PR TITLE
Include .rbenv-vars in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,6 @@
 # RubyMine settings
 .idea/
 
-# Figaro
+# ENV variables
 config/application.yml
+.rbenv-vars


### PR DESCRIPTION
Some of us are using [`rbenv-vars`](https://github.com/rbenv/rbenv-vars). This is to make sure they don't get exposed.