### PR TITLE
add procfile and local_server script

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,1 @@
+server: bundle exec rails s -p 3000

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Template for new Rails projects.
 To get going clone this repository and perform the following steps:
 
 1. Clone this repository
-1. You can now run `scripts/setup`, which will help you in configuring the template.
+1. You can now run `bin/configure`, which will help you in configuring the template.
    Alternatively perform all of the following steps manually.
 1. Change application name in `config/application.rb`.
 1. Update `database.yml` to reflect the new application name.

--- a/bin/configure
+++ b/bin/configure
@@ -32,8 +32,3 @@ fgrep -rn "TODO:" app config spec | while read -r line ; do
 done 
 echo "  * Update project name in package.json"
 
-
-
-
-
-

--- a/bin/local_server
+++ b/bin/local_server
@@ -1,0 +1,2 @@
+#!/bin/sh
+foreman start -f Procfile.dev


### PR DESCRIPTION
I like to have a script in every project called local_server that
will boot the application, not matter what stack it is on or which
services need to be initialized so that there is no ambiguity about
launching a local instance. We should also use Procfile.dev by default
since it is almost always necessary to run multiple processes and for
those who prefer running them in the same shell, this makes it trivial.