### PR TITLE
added heroku restart on deployment

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -21,3 +21,5 @@ checkout:
 #          timeout: 300
 #      - heroku run rake db:migrate --app <APPNAME>:
 #          timeout: 300
+#      - heroku restart --app <APPNAME>:
+#          timeout: 300


### PR DESCRIPTION
@citizen428 is this still necessary? I feel like we recently got bitten by not restarting in our auto deploys...maybe rails 5 doesn't require it?