### PR TITLE
adding quote before/after environment variable of google analytics id

### DIFF
--- a/app/views/layouts/_google_analytics.html.erb
+++ b/app/views/layouts/_google_analytics.html.erb
@@ -5,7 +5,7 @@
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-    ga('create', <%= ENV['GOOGLE_ANALYTICS_ID'] %>, 'auto');
+    ga('create', '<%= ENV['GOOGLE_ANALYTICS_ID'] %>', 'auto');
     ga('send', 'pageview');
     ga('require', 'ecommerce');
 </script>


### PR DESCRIPTION
so we don't have to put ' or " in value of that environment value.