### PR TITLE
updated Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-server: bundle exec rails s -p 3000
-worker: bundle exec sidekiq
+web: bundle exec puma -C config/puma.rb
+worker: bundle exec sidekiq -C config/sidekiq.yml


### PR DESCRIPTION
1. changed `server` -> `web` (this appears to be the heroku default, so you get web, server and worker if you don't use web in the Procfile)
2. Explicitly loading puma instead of using rails s. It isn't clear to me based on [this thread] whether rails reads from the config properly. Unless there is a downside to initiating puma explicitly (or if someone wants to confirm that rails s behaves properly) I prefer the explicit references.
3. Explicitly referencing the sidekiq config. Again not sure if this is necessary but I do like the explicit references

Thoughts?