### PR TITLE
Add NakayoshiFork

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,7 @@ group :production do
   # Remove this if the app is not hosted on Heroku
   gem 'heroku-deflater'
   gem 'lograge'
+  gem 'nakayoshi_fork'
   gem 'rack-timeout'
   gem 'rails_12factor'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,12 +132,13 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
-    mini_portile2 (2.2.0)
+    mini_portile2 (2.3.0)
     minitest (5.10.3)
+    nakayoshi_fork (0.0.3)
     newrelic_rpm (4.4.0.336)
     nio4r (2.1.0)
-    nokogiri (1.8.0)
-      mini_portile2 (~> 2.2.0)
+    nokogiri (1.8.1)
+      mini_portile2 (~> 2.3.0)
     orm_adapter (0.5.0)
     parallel (1.12.0)
     parser (2.4.0.0)
@@ -335,6 +336,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   lograge
   memory_profiler
+  nakayoshi_fork
   newrelic_rpm
   pg (~> 0.18)
   poltergeist
@@ -368,4 +370,4 @@ RUBY VERSION
    ruby 2.4.2p198
 
 BUNDLED WITH
-   1.15.4
+   1.16.0.pre.2


### PR DESCRIPTION
**Explain Like I'm 5**

* Ruby 2.1 added a generational garbage collector.
* Ruby 2.2 raised the generation count for being considered an "old" object to 3.
* Generation count is stored in the object struct on the C side.
* This is not Copy-On-Write friendly and may trigger copying entire memory pages, thus increasing the memory consumption across workers.

**Solution**

This gem fixes it by forcing several GC runs *before* forking new web server processes, which means that the core application (which will all be long lasting objects) already have a GC count of 3 and are considered old objects, which leads to less memory pages being copied into the forks.

**Should we do this?**

* This is used in production at GitHub and GitHub's Aaron Patterson recommended this to everyone running a forking web server — like Puma in "clustered mode" — in production at RubyConf Malaysia.

* The gem's author is Koichi Sasad (ko1), who actually wrote the GC for Ruby 2.2 and who also works at Heroku. 

NB: our standard Puma config only uses threads, not workers, but by adding this we'll be save in all scenarios and their is no overhead for us.