### PR TITLE
Bump Bootstrap 4 to beta 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@rails/webpacker": "^3.0.1",
-    "bootstrap": "4.0.0-beta",
+    "bootstrap": "4.0.0-beta.2",
     "jquery": "^3.2.1",
     "jquery-ujs": "^1.2.2",
     "popper.js": "^1.12.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -896,9 +896,9 @@ boom@2.x.x:
   dependencies:
     hoek "2.x.x"
 
-bootstrap@4.0.0-beta:
-  version "4.0.0-beta"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.0.0-beta.tgz#dc5928175d2e71310bc668cf9e05a907211b72a6"
+bootstrap@4.0.0-beta.2:
+  version "4.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.0.0-beta.2.tgz#4d67d2aa2219f062cd90bc1247e6747b9e8fd051"
 
 brace-expansion@^1.1.7:
   version "1.1.8"


### PR DESCRIPTION
Bootstrap 4 beta 2 has been released 13hr ago (Oct 19, 2017). Many mixins bugs introduced in beta1 have been fixed in this version along with other improvements 👍 

### Changes
- Bumps Bootstrap to v4.0.0-beta.2

### Notes
- More info on the release can be found here https://blog.getbootstrap.com/2017/10/19/bootstrap-4-beta-2/