### PR TITLE
Move from FactoryGirl to FactoryBot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -108,7 +108,7 @@ end
 group :test do
   gem 'bundler-audit', require: false
   gem 'capybara', '~> 2.13.0'
-  gem 'factory_girl_rails'
+  gem 'factory_bot_rails'
   gem 'rspec-rails', '~> 3.7'
   gem 'rspec_junit_formatter'
   gem 'selenium-webdriver'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,10 +86,10 @@ GEM
     diff-lcs (1.3)
     erubi (1.7.0)
     execjs (2.7.0)
-    factory_girl (4.8.1)
+    factory_bot (4.8.2)
       activesupport (>= 3.0.0)
-    factory_girl_rails (4.8.0)
-      factory_girl (~> 4.8.0)
+    factory_bot_rails (4.8.2)
+      factory_bot (~> 4.8.2)
       railties (>= 3.0.0)
     ffi (1.9.18)
     figaro (1.1.1)
@@ -316,7 +316,7 @@ DEPENDENCIES
   byebug
   capybara (~> 2.13.0)
   devise (~> 4.3.0)
-  factory_girl_rails
+  factory_bot_rails
   figaro
   foreman
   heroku-deflater
@@ -337,7 +337,7 @@ DEPENDENCIES
   rack-timeout
   rails (~> 5.1.4)
   rails_12factor
-  rspec-rails (~> 3.7.0)
+  rspec-rails (~> 3.7)
   rspec_junit_formatter
   rubocop
   ruby-prof

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,7 +25,7 @@ module RailsNew
     config.generators do |g|
       # Create appropriate tests in spec/ not test/
       g.test_framework :rspec, fixture: true
-      g.fixture_replacement :factory_girl, dir: 'spec/factories'
+      g.fixture_replacement :factory_bot, dir: 'spec/factories'
 
       # Don't generate helpers, JS, CSS or view specs for controllers
       # See: http://guides.rubyonrails.org/generators.html

--- a/spec/support/factory_girl.rb
+++ b/spec/support/factory_girl.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 RSpec.configure do |config|
-  config.include FactoryGirl::Syntax::Methods
+  config.include FactoryBot::Syntax::Methods
 end


### PR DESCRIPTION
Background: https://robots.thoughtbot.com/factory_bot

> We’re renaming factory_girl to factory_bot (and factory_girl_rails to factory_bot_rails). All the same functionality of factory_girl, now under a different name.