### PR TITLE
added test env email host

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -27,7 +27,10 @@ Rails.application.configure do
   end
 
   # In production, :host should be set to the actual host of your application.
-  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+  config.action_mailer.default_url_options = {
+    host: 'localhost',
+    port: ENV.fetch("PORT") { 3000 }
+  }
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -35,7 +35,10 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :test
 
   # Emails generated in the test suite that include urls need a host value.
-  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+  config.action_mailer.default_url_options = {
+    host: 'localhost',
+    port: ENV.fetch("PORT") { 3000 }
+  }
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -34,6 +34,9 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
+  # Emails generated in the test suite that include urls need a host value.
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 


### PR DESCRIPTION
Is this the right way to add the test env default host/port? Seems like we should obey the test server's port. Also seems like we should be using `ENV.fetch('PORT')` here and in `development.rb`? Not a big deal, just hit this in the after third app when I was adding devise confirmation specs.