### PR TITLE
simplify application.yml.example

### DIFF
--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -1,4 +1,2 @@
-development:
-  RAILS_WEB_CONCURRENCY: '1'
-  RAILS_MAX_THREADS: '1'
-  REDIS_URL: "http://localhost:6379"
+RAILS_WEB_CONCURRENCY: '1'
+RAILS_MAX_THREADS: '1'


### PR DESCRIPTION
Its nice to have the env variables at the root of this file so that the test suite will pick them up; even though you won't interact with third party systems, you frequently need the keys defined for initialization to succeed. Also, while multiple environments is in principle a good feature of figaro, it seems to encourage people to save keys/secrets for remote servers on their local machines, whereas I think in general you really only want those defined on the remote servers themselves. I'm inclined to encourage people against storing anything of real value in this location, and instead exclusively use it for dev/test env definitions.

Thoughts?