### PR TITLE
default ams adapter

### DIFF
--- a/config/initializers/active_model_serializers.rb
+++ b/config/initializers/active_model_serializers.rb
@@ -1,0 +1,1 @@
+ActiveModelSerializers.config.adapter = :json


### PR DESCRIPTION
I'm definitely open to doing things differently but historically our APIs we always use a semantically relevant root node, so if I fetch `GET /cars/1` then my response body is something like `{ car: { id: 1 } }`, or `{ cars: [ { id: 1 } ] }` if I fetch `GET /cars`.

By default AMS will [not include a root node](https://github.com/rails-api/active_model_serializers/blob/0-10-stable/docs/howto/add_root_key.md), which I find odd given the (historical?) security concern in returning [naked arrays in JSON](https://haacked.com/archive/2008/11/20/anatomy-of-a-subtle-json-vulnerability.aspx/).

Anyway, I think best practice may be transitioning to generic roots (e.g. `data:`). But either way I think specifying a preferred/sensible default in new apps is best.