### PR TITLE
Add JS to make gtag work with Turbolinks

### DIFF
--- a/app/assets/javascripts/google_analytics.js
+++ b/app/assets/javascripts/google_analytics.js
@@ -1,0 +1,5 @@
+$(document).on('turbolinks:load', function () {
+  if (typeof gtag === 'function' && typeof SETTINGS.google_analytics_id != "undefined") {
+    gtag('config', SETTINGS.google_analytics_id, { page_path: window.location.pathname });
+  }
+});

--- a/app/views/layouts/_google_analytics.html.erb
+++ b/app/views/layouts/_google_analytics.html.erb
@@ -1,11 +1,12 @@
 <% if ENV['GOOGLE_ANALYTICS_ID'].present? %>
 <!-- Global Site Tag (gtag.js) - Google Analytics -->
+<script>
+  SETTINGS.google_analytics_id = "<%= ENV['GOOGLE_ANALYTICS_ID'] %>"
+</script>
 <script async src="<%= "https://www.googletagmanager.com/gtag/js?id=#{ENV['GOOGLE_ANALYTICS_ID']}" %>"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments)};
   gtag('js', new Date());
-
-  gtag('config', '<%= ENV['GOOGLE_ANALYTICS_ID'] %>');
 </script>
 <% end %>

--- a/app/views/layouts/_js_setup.html.erb
+++ b/app/views/layouts/_js_setup.html.erb
@@ -1,0 +1,3 @@
+<script>
+  var SETTINGS = {};
+</script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,6 +4,7 @@
     <%= csrf_meta_tags %>
 
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+    <%= render partial: 'layouts/js_setup' %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
 
     <meta charset='UTF-8'>


### PR DESCRIPTION
@roonglit pointed out a problem with our current Google Analytics implementation, namely that it won't work nicely with Turbolinks, since the script in the head won't execute again. 

Resources:

* [Tracking virtual pageviews](https://developers.google.com/analytics/devguides/collection/gtagjs/single-page-applications#tracking_virtual_pageviews)
* [gist](https://gist.github.com/esBeee/545653241530f8f2c2e16371bec56f20#gistcomment-2310777)