### PR TITLE
Update ApplicationDecorator

### DIFF
--- a/app/decorators/application_decorator.rb
+++ b/app/decorators/application_decorator.rb
@@ -2,6 +2,8 @@
 
 require 'forwardable'
 
+# Generic decorator base class. For view-specific decorators please use the
+# <tt>ApplicationPresenter</tt> base class instead.
 class ApplicationDecorator
   extend Forwardable
 
@@ -38,6 +40,13 @@ class ApplicationDecorator
     define_method :respond_to_missing? do |m, include_private = false|
       wrapped.respond_to?(m) || super(m, include_private)
     end
+  end
+
+  # Wraps each object in the provided collection in a decorator instance.
+  #
+  # @returns [Array<Ojbect>]
+  def self.decorate_collection(collection)
+    collection.map { |element| new(element) }
   end
 
   # Returns the wrapped object.

--- a/spec/decorators/application_decorator_spec.rb
+++ b/spec/decorators/application_decorator_spec.rb
@@ -59,4 +59,12 @@ describe ApplicationDecorator do
       expect(subject.respond_to?(:age)).to be true
     end
   end
+
+  describe '.decorate_collection' do
+    it 'wraps all elements of the collection in a decorator' do
+      decorated = TestUserDecorator1.decorate_collection([user, user])
+      expect(decorated.size).to eq 2
+      expect(decorated).to all(be_a TestUserDecorator1)
+    end
+  end
 end


### PR DESCRIPTION
Just added a `decorate_collection` method and updated the docs to reference `ApplicationPresenter` (which therefore should be merged first).

Note: I did not think adding a `.call` method was valuable here, it'd essentially be one level of indirection around `.new`, whereas in `ApplicationPresenter` the main interface always was a differently named class method (`.present`). Thoughts?