### PR TITLE
recommend a way to set and reference the server host

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,10 @@ heroku buildpacks:add heroku/ruby
 
 | Variable              | Comment                                                                 |
 | --------------------- | ----------------------------------------------------------------------- |
-| GOOGLE_ANALYTICS_ID   | Will be added to the main application layout if set                     |
 | BLOCK_HTTP_TRACE      | Disable HTTP TRACE method if set to true/t/1                            |
 | DATABASE_URL          | Used for `production` env, automatically set by Heroku                  |
+| GOOGLE_ANALYTICS_ID   | Will be added to the main application layout if set                     |
+| HOST                  | Your base URI, e.g. https://myapp.herokuapp.com                         |
 | HTTP_METHOD_BLACKLIST | If you want to block more than just TRACE, e.g. `"TRACE,OPTIONS"`       |
 | PORT                  | Port Puma will listen on, defaults to 3000                              |
 | RAILS_LOG_TO_STDOUT   | Set by Heroku Ruby buildpack, set manually on other platforms if needed |

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -1,2 +1,3 @@
+HOST: 'http://localhost:3000'
 RAILS_WEB_CONCURRENCY: '1'
 RAILS_MAX_THREADS: '1'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -113,6 +113,8 @@ Rails.application.configure do
   # Uncomment and configure the following configuration option(s).
   # If your environment is more difficult (subdomains or different TLDs), try
   # https://github.com/synack/rack-allowed_hosts instead.
-  # config.action_controller.default_url_options = { host: "www.yoursite.com" }
-  # config.action_controller.asset_host = "www.yoursite.com"
+  # config.action_controller.default_url_options = {
+  #   host: Constants::HOST_URI.host
+  # }
+  # config.action_controller.asset_host = Constants::HOST_URI.host
 end

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Constants
+  HOST_URI = URI.parse(ENV.fetch('HOST'))
+end


### PR DESCRIPTION
I feel like I'm always doing this slightly different ways across applications, would love to standardize it.