### PR TITLE
Add form generator

### DIFF
--- a/lib/generators/form/USAGE
+++ b/lib/generators/form/USAGE
@@ -1,0 +1,27 @@
+Description:
+    Generates a form for the given model.
+
+Examples:
+    `rails generate form user`
+
+        # app/forms/user_form.rb
+        class UserForm < ApplicationForm
+          form_attributes
+        end
+
+    `rails generate form user name email`
+
+        # app/forms/user_form.rb
+        class UserForm < ApplicationForm
+          form_attributes :name, :email
+        end
+
+    `rails generate form signup name email --resource User`
+    `rails generate form signup name email -r User`
+
+        # app/forms/signup_form.rb
+        class SignupForm < ApplicationForm
+          resource_class User
+
+          form_attributes :name, :email
+        end

--- a/lib/generators/form/form_generator.rb
+++ b/lib/generators/form/form_generator.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class FormGenerator < Rails::Generators::NamedBase
+  source_root File.expand_path('templates', __dir__)
+
+  class_option :resource,
+               type: :string,
+               default: nil,
+               aliases: '-r',
+               banner: 'CLASS',
+               desc: 'Specifies the resource class'
+  argument :form_attributes, type: :array, default: []
+
+  def create_form_file
+    template 'form.rb.tt',
+             File.join('app', 'forms', class_path, "#{file_name}_form.rb")
+  end
+
+  private
+
+  def resource_class_name
+    options['resource']
+  end
+
+  def form_attribute_names
+    form_attributes.map { |a| a.to_sym.inspect }
+  end
+end

--- a/lib/generators/form/templates/form.rb.tt
+++ b/lib/generators/form/templates/form.rb.tt
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+<% module_namespacing do -%>
+class <%= class_name %>Form < ApplicationForm
+<% if resource_class_name -%>
+  resource_class <%= resource_class_name %>
+
+<% end -%>
+  form_attributes <%= form_attribute_names.join(', ') %>
+end
+<% end -%>


### PR DESCRIPTION
This PR adds a generator for our forms inheriting from `ApplicationForm`.

Output of `rails generate form --help`:

```
Usage:
  rails generate form NAME [one two three] [options]

Options:
      [--skip-namespace], [--no-skip-namespace]  # Skip namespace (affects only isolated applications)
  -r, [--resource=CLASS]                         # Specifies the resource class

Runtime options:
  -f, [--force]                    # Overwrite files that already exist
  -p, [--pretend], [--no-pretend]  # Run but do not make any changes
  -q, [--quiet], [--no-quiet]      # Suppress status output
  -s, [--skip], [--no-skip]        # Skip files that already exist

Description:
    Generates a form for the given model.

Examples:
    `rails generate form user`

        # app/forms/user_form.rb
        class UserForm < ApplicationForm
          form_attributes
        end

    `rails generate form user name email`

        # app/forms/user_form.rb
        class UserForm < ApplicationForm
          form_attributes :name, :email
        end

    `rails generate form signup name email --resource User`
    `rails generate form signup name email -r User`

        # app/forms/signup_form.rb
        class SignupForm < ApplicationForm
          resource_class User

          form_attributes :name, :email
        end
```
