### PR TITLE
Add ApplicationController#expose

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,3 @@
+--protected
+--private
+

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,4 +5,23 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   before_action :authenticate_user!
+
+  private
+
+  # A shorthand for passing locals to views, avoiding implicitly passed instance
+  # variables.
+  #
+  # The following calls are equivalent to each other:
+  #   render action: :new, locals: { the_anser: 42 }
+  #   expose :new, the_answer: 42
+  #
+  #   render locals: { the_anser: 42 }
+  #   expose the_anser: 42
+  #
+  # @param action [Symbol] action to render, only necessary if not default
+  # @param locals [Hash<Symbol, Object>] locals to be passed to the view
+  # @return [void]
+  def expose(action = nil, **locals)
+    render action: action, locals: locals
+  end
 end


### PR DESCRIPTION
I know that all the CoolKids™ do JS frontends now, but for the ones still doing boring old server rendered UIs it has been established over the years that explicitly passed locals have some advantages over implicitly copied instance variables:

1. Instance variables can be manipulated in many places, i.e. before/after actions (that may even be inherited, the horrors I've seen).
2. Instance variables default to `nil`, so typos will lead to a `NoMethodError` on `nil` which can be quite the red herring, whereas a mis-typed local will raise a `NameError` as $DEITY intended.

In my private projects I started using a method called `expose` (name borrowed from [Hanami](http://hanamirb.org/guides/actions/exposures/)) which makes it less cumbersome to pass locals to views:

```ruby
# before
render locals: { one: :a, two: :b }
# after
expose one: :a, two: :b
```

It also supports passing in the action:

```ruby
# before
render :new, locals: { one: :a, two: :b }
# after
expose :new, one: :a, two: :b
```

It's documented and should be fine to merge, if you don't like it, don't use ¯\_(ツ)_/¯