### PR TITLE
Forward :to_partial_path in ApplicationPresenter

### DIFF
--- a/app/presenters/application_presenter.rb
+++ b/app/presenters/application_presenter.rb
@@ -13,7 +13,8 @@ class ApplicationPresenter < ApplicationDecorator
   forward :id,
           :model_name,
           :to_key,
-          :to_param
+          :to_param,
+          :to_partial_path
 
   # Wraps the provided object in a presenter and yields it to an optional block.
   # If no block is provided, this essentially behaves like <tt>.new</tt>.


### PR DESCRIPTION
Allows us to use shorthand syntax for calling partials and layouts when using presenters.
```
UserPresenter.(@user) do |user|
  render user
```
Instead of 
```
UserPresenter.(@user) do |user|
  render partial: 'users/user', locals: { user: user }
```
