### PR TITLE
update invalid authenticity language

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery with: :exception
   rescue_from ActionController::InvalidAuthenticityToken do
-    flash[:notice] = I18n.t('app.session_expired')
+    flash[:notice] = I18n.t('app.authenticity_token_expired')
     redirect_back fallback_location: root_path, allow_other_host: false
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,4 +31,6 @@
 
 en:
   app:
-    session_expired: Your session expired, please try again.
+    authenticity_token_expired: |
+      Your browser window has been idle for too long. As a security measure you
+      will need to resubmit your request.


### PR DESCRIPTION
even if you are attempting to login you'll see "session expired". that language doesn't really capture the situation in an intuitive way for the user...proposed update here