### PR TITLE
Sprockets upgrade

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -286,7 +286,7 @@ GEM
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)


### PR DESCRIPTION
[Rails Asset Pipeline Directory Traversal Vulnerability (CVE-2018-3760)](https://blog.heroku.com/rails-asset-pipeline-vulnerability)