### PR TITLE
change sign_in method name so it will not conflict with devise's one

### DIFF
--- a/spec/support/helpers/session_helpers.rb
+++ b/spec/support/helpers/session_helpers.rb
@@ -10,7 +10,7 @@ module SpecHelpers
       click_button('Sign up')
     end
 
-    def sign_in(email, password)
+    def sign_in_with(email, password)
       visit(new_user_session_path)
       fill_in('Email', with: email)
       fill_in('Password', with: password)


### PR DESCRIPTION
* I tried to write a system spec and use this method, but it uses devise's one instead. 