### PR TITLE
Remove rails_12factor gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,7 +75,6 @@ group :production do
   gem 'lograge'
   gem 'nakayoshi_fork'
   gem 'rack-timeout'
-  gem 'rails_12factor'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -198,11 +198,6 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.0.4)
       loofah (~> 2.2, >= 2.2.2)
-    rails_12factor (0.0.3)
-      rails_serve_static_assets
-      rails_stdout_logging
-    rails_serve_static_assets (0.0.5)
-    rails_stdout_logging (0.0.5)
     railties (5.2.0)
       actionpack (= 5.2.0)
       activesupport (= 5.2.0)
@@ -362,7 +357,6 @@ DEPENDENCIES
   rack-mini-profiler
   rack-timeout
   rails (~> 5.2.0)
-  rails_12factor
   rspec-rails (~> 3.7)
   rspec_junit_formatter
   rubocop


### PR DESCRIPTION
The `rails_12factor` gem is no longer needed for Rails 5 apps. https://github.com/heroku/rails_12factor#rails-5