### PR TITLE
Update rack_timeout.rb

### DIFF
--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -7,4 +7,4 @@
 
 # Rack::Timeout logs a LOT when the logger is at the DEBUG level (i.e. in
 # development).
-Rack::Timeout.unregister_state_change_observer(:logger) if Rails.env.development?
+Rack::Timeout.unregister_state_change_observer(:logger) unless Rails.env.development?

--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -1,0 +1,10 @@
+# Have Rack::Timeout kill requests after a specified amount of time. The timeout
+# limit is configured by the RACK_TIMEOUT_SERVICE_TIMEOUT environment variable.
+# See https://github.com/heroku/rack-timeout/blob/master/doc/settings.md for
+# other config options.
+
+# See https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#timeout
+
+# Rack::Timeout logs a LOT when the logger is at the DEBUG level (i.e. in
+# development).
+Rack::Timeout.unregister_state_change_observer(:logger) if Rails.env.development?


### PR DESCRIPTION
Am guessing an error here as the Gemfile has RackTimeout in the production group, also this would make sense in the context of the comments. Unregister the logger unless in development mode. 

Side note: the app won't boot without some changes here. You get an error:

```
/Users/person/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/bootsnap-1.3.0/lib/bootsnap/load_path_cache/core_ext/active_support.rb:43:in `load_missing_constant': uninitialized constant Rack::Timeout (NameError)
```