### PR TITLE
Simplify Circle 2 config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,16 +1,22 @@
 version: 2
 jobs:
-  checkout-code:
+  test:
+    parallelism: 3
     working_directory: ~/src
     docker:
       - image: circleci/ruby:2.5.1-node-browsers
-    steps:
-      - checkout
-
-  yarn-install:
-    working_directory: ~/src
-    docker:
-      - image: circleci/ruby:2.5.1-node-browsers
+        environment:
+          BUNDLE_JOBS: 3
+          BUNDLE_RETRY: 3
+          BUNDLE_PATH: vendor/bundle
+          HOST: http://example.com
+          PGHOST: 127.0.0.1
+          PGUSER: lockstep
+          RAILS_ENV: test
+      - image: circleci/postgres:10-alpine-ram
+        environment:
+          POSTGRES_DB: rails_new_test
+          POSTGRES_USER: lockstep
     steps:
       - checkout
 
@@ -25,17 +31,6 @@ jobs:
           key: yarn-{{ checksum "yarn.lock" }}
           paths:
             - ~/.yarn-cache
-
-  bundle-install:
-    working_directory: ~/src
-    docker:
-      - image: circleci/ruby:2.5.1-node-browsers
-        environment:
-          BUNDLE_JOBS: 3
-          BUNDLE_RETRY: 3
-          BUNDLE_PATH: vendor/bundle
-    steps:
-      - checkout
 
       - restore_cache:
           key: bundle-{{ checksum "Gemfile.lock" }}
@@ -52,33 +47,6 @@ jobs:
       - run:
           name: Verify bundle security
           command: bundle exec bundle-audit check --update
-
-  test:
-    parallelism: 3
-    working_directory: ~/src
-    docker:
-      - image: circleci/ruby:2.5.1-node-browsers
-        environment:
-          HOST: http://example.com
-          PGHOST: 127.0.0.1
-          PGUSER: lockstep
-          RAILS_ENV: test
-      - image: circleci/postgres:10-alpine-ram
-        environment:
-          POSTGRES_DB: rails_new_test
-          POSTGRES_USER: lockstep
-    steps:
-      - checkout
-
-      - restore_cache:
-          key: yarn-{{ checksum "yarn.lock" }}
-
-      - restore_cache:
-          key: bundle-{{ checksum "Gemfile.lock" }}
-
-      - run:
-          name: Install bundle
-          command: bin/bundle install --path vendor/bundle
 
       - run:
           name: Wait for DB
@@ -139,17 +107,7 @@ workflows:
   version: 2
   build-deploy:
     jobs:
-      - checkout-code
-      - yarn-install:
-          requires:
-            - checkout-code
-      - bundle-install:
-          requires:
-            - checkout-code
-      - test:
-          requires:
-            - yarn-install
-            - bundle-install
+      - test
       - deploy-master:
           requires:
             - test


### PR DESCRIPTION
While workflows are a nice feature and running Bundler and Yarn in parallel is nice, it does make the config quite a bit more complicated and verbose, so I think we should remove it from our default template (the caching makes sure it's still a rather efficient process most of the time anyway).