### PR TITLE
PG upgrade

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'rails', '~> 5.2.1'
 gem 'webpacker', '~> 3.0'
 
 # Use postgresql as the database for Active Record
-gem 'pg', '~> 0.18'
+gem 'pg', '~> 1.1.0'
 
 # Use Puma as the app server
 gem 'puma', '~> 3.11'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,7 +153,7 @@ GEM
     parallel (1.12.1)
     parser (2.5.1.2)
       ast (~> 2.4.0)
-    pg (0.21.0)
+    pg (1.1.3)
     powerpack (0.1.2)
     pry (0.11.3)
       coderay (~> 1.1.0)
@@ -347,7 +347,7 @@ DEPENDENCIES
   nakayoshi_fork
   newrelic_rpm
   nullalign
-  pg (~> 0.18)
+  pg (~> 1.1.0)
   pry-byebug
   pry-doc
   pry-rails

--- a/README.md
+++ b/README.md
@@ -93,8 +93,9 @@ All of the following have been installed and pre-configured:
 
 ### Base system
 
-* Rails 5.2.0
+* Rails 5.2.1
 * Ruby 2.5.1
+* PostgreSQL >= 9.2
 * [pg](https://github.com/ged/ruby-pg) for `ActiveRecord`
 
 ### General


### PR DESCRIPTION
Version `1.x` has been out for a while now ([changelog](https://github.com/ged/ruby-pg/blob/master/History.rdoc)).

Since this is not a concern:

>Remove compatibility code for Ruby < 2.0 and PostgreSQL < 9.2

I think it's time to upgrade. Updated Readme to match the requirements.