### PR TITLE
Implicitly unwrap decorators in policies

### DIFF
--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -5,7 +5,8 @@ class ApplicationPolicy
 
   def initialize(user, record)
     @user = user
-    @record = record
+    # Transparently unwrap presenters and decorators
+    @record = record.respond_to?(:wrapped) ? record.wrapped : record
   end
 
   def index?

--- a/spec/policies/application_policy_spec.rb
+++ b/spec/policies/application_policy_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class TestUser < User; end
+class TestUserPresenter < ApplicationPresenter; end
+
+describe ApplicationPolicy do
+  it 'implicitly unwraps decorators and presenters' do
+    current_user = User.new
+    presented_user = TestUser.new
+    user_presenter = TestUserPresenter.new(presented_user)
+    policy = described_class.new(current_user, user_presenter)
+    expect(policy.record).to eq(presented_user)
+  end
+end


### PR DESCRIPTION
Also works for presenters, since they are subclasses of decorators.