### PR TITLE
Nokogiri, Node, Yarn upgrades

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,7 +146,7 @@ GEM
     nakayoshi_fork (0.0.4)
     newrelic_rpm (5.3.0.346)
     nio4r (2.3.1)
-    nokogiri (1.8.4)
+    nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     nullalign (0.0.3)
     orm_adapter (0.5.0)

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "rails_new",
   "private": true,
   "engines": {
-    "node": ">=6.0.0 <10",
-    "yarn": ">=1.6.0"
+    "node": ">=8.9.0",
+    "yarn": ">=1.9.0"
   },
   "dependencies": {
     "@rails/webpacker": "^3.5.3",


### PR DESCRIPTION
#### Changes

Another day, another Nokogiri upgrade 😆 

1. Upgrade Nokogiri for `CVE-2018-14404`
1. Upgrade Node and Yarn. I just had a case when a package required Node `>=8.9.0` so that sounds like a reasonable minimum. Tested on Heroku, issues they had with Node 10 are long gone.