### PR TITLE
remove response_json helper

### DIFF
--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
-require_relative 'helpers/response_helpers'
 require_relative 'helpers/session_helpers'
 
 RSpec.configure do |config|
   config.include SpecHelpers::SessionHelpers, type: :system
-  config.include SpecHelpers::ResponseHelpers, type: :request
 end

--- a/spec/support/helpers/response_helpers.rb
+++ b/spec/support/helpers/response_helpers.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-module SpecHelpers
-  module ResponseHelpers
-    def response_json
-      response.parsed_body
-    end
-  end
-end

--- a/spec/support/shared_examples/api_requests.rb
+++ b/spec/support/shared_examples/api_requests.rb
@@ -6,7 +6,7 @@ shared_examples 'a successful resource request' do |root|
   end
 
   it 'returns the resource' do
-    expect(response_json[root]).to be_a Hash
+    expect(response.parsed_body[root]).to be_a Hash
   end
 end
 
@@ -16,7 +16,7 @@ shared_examples 'a successful resource list request' do |root|
   end
 
   it 'returns the resource list' do
-    expect(response_json[root]).to be_a Array
+    expect(response.parsed_body[root]).to be_a Array
   end
 end
 
@@ -26,7 +26,7 @@ shared_examples 'a successful resource create' do |root|
   end
 
   it 'returns the new resource' do
-    expect(response_json[root]).to be_a Hash
+    expect(response.parsed_body[root]).to be_a Hash
   end
 end
 


### PR DESCRIPTION
Rails 5 gives us a new `response.parsed_body` method to access parses requests body's based on their content type. This seems to make this helper less necessary and less conventional—it seems like we should leverage `parsed_body`directly instead.

NOTE: In larger projects leveraging this template this may break a lot of specs, but a quick find/replace should immediately fix them.