### PR TITLE
Bundle splitting

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,6 @@
-require: rubocop-rspec
+require:
+  - rubocop-performance
+  - rubocop-rspec
 
 AllCops:
   TargetRubyVersion: 2.4
@@ -56,6 +58,11 @@ Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
 
 #################### Lint ##################################
+
+Lint/FlipFlop:
+  Description: 'Checks for flip flops'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-flip-flops'
+  Enabled: true
 
 Lint/AmbiguousOperator:
   Description: >-
@@ -269,13 +276,6 @@ Performance/ReverseEach:
   Reference: 'https://github.com/JuanitoFatas/fast-ruby#enumerablereverseeach-vs-enumerablereverse_each-code'
   Enabled: true
 
-Performance/Sample:
-  Description: >-
-    Use `sample` instead of `shuffle.first`,
-    `shuffle.last`, and `shuffle[Fixnum]`.
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#arrayshufflefirst-vs-arraysample-code'
-  Enabled: true
-
 Performance/Size:
   Description: >-
     Use `size` instead of `count` for counting
@@ -438,11 +438,6 @@ Style/FrozenStringLiteralComment:
   Description: >-
     Add the frozen_string_literal comment to the top of files
     to help transition from Ruby 2.3.0 to Ruby 3.0.
-  Enabled: true
-
-Style/FlipFlop:
-  Description: 'Checks for flip flops'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-flip-flops'
   Enabled: true
 
 Style/FormatString:
@@ -626,6 +621,13 @@ Style/WordArray:
   Description: 'Use %w or %W for arrays of words.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-w'
   Enabled: false
+
+Style/Sample:
+  Description: >-
+    Use `sample` instead of `shuffle.first`,
+    `shuffle.last`, and `shuffle[Fixnum]`.
+  Reference: 'https://github.com/JuanitoFatas/fast-ruby#arrayshufflefirst-vs-arraysample-code'
+  Enabled: true
 
 #################### Testing ###########################
 

--- a/Gemfile
+++ b/Gemfile
@@ -105,6 +105,7 @@ group :development do
   gem 'listen', '>= 3.0.5', '< 3.2'
   gem 'nullalign'
   gem 'rubocop', require: false
+  gem 'rubocop-performance'
   gem 'rubocop-rspec', require: false
   # Spring speeds up development by keeping your application running in the background.
   # Read more: https://github.com/rails/spring
@@ -120,7 +121,7 @@ end
 group :test do
   gem 'bundler-audit', require: false
   # Adds support for Capybara system testing and selenium driver
-  gem 'capybara', '~> 2.15'
+  gem 'capybara'
   # Easy installation and use of chromedriver (and others) to run system tests
   # with Chrome
   gem 'factory_bot_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,13 +65,14 @@ GEM
       bundler (>= 1.2.0, < 3)
       thor (~> 0.18)
     byebug (11.0.1)
-    capybara (2.18.0)
+    capybara (3.18.0)
       addressable
       mini_mime (>= 0.1.3)
-      nokogiri (>= 1.3.3)
-      rack (>= 1.0.0)
-      rack-test (>= 0.5.4)
-      xpath (>= 2.0, < 4.0)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (~> 1.2)
+      xpath (~> 3.2)
     childprocess (1.0.1)
       rake (< 13.0)
     coderay (1.1.2)
@@ -206,6 +207,7 @@ GEM
       ffi (~> 1.0)
     rbtree3 (0.5.0)
     redis (4.1.0)
+    regexp_parser (1.4.0)
     request_store (1.4.1)
       rack (>= 1.4)
     responders (2.4.1)
@@ -238,6 +240,8 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.6)
+    rubocop-performance (1.1.0)
+      rubocop (>= 0.67.0)
     rubocop-rspec (1.32.0)
       rubocop (>= 0.60.0)
     ruby-prof (0.17.0)
@@ -335,7 +339,7 @@ DEPENDENCIES
   bullet
   bundler-audit
   byebug
-  capybara (~> 2.15)
+  capybara
   devise (~> 4.6.0)
   factory_bot_rails
   fast_jsonapi
@@ -361,6 +365,7 @@ DEPENDENCIES
   rspec-rails (~> 3.7)
   rspec_junit_formatter
   rubocop
+  rubocop-performance
   rubocop-rspec
   ruby-prof
   sass-rails (~> 5.0.4)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,7 @@
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= render partial: 'layouts/google_analytics' %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
 
     <%= csrf_meta_tags %>
     <%= render partial: 'layouts/favicon' %>

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,3 +1,20 @@
-const { environment } = require('@rails/webpacker')
+const { environment } = require("@rails/webpacker");
 
-module.exports = environment
+environment.splitChunks(config =>
+  Object.assign({}, config, {
+    optimization: {
+      splitChunks: {
+        cacheGroups: {
+          vendor: {
+            test: /node_modules/,
+            chunks: "all",
+            name: "vendor",
+            enforce: true
+          }
+        }
+      }
+    }
+  })
+);
+
+module.exports = environment;


### PR DESCRIPTION
#### Changes

1. Update dependencies. `rubocop-performance` is added as a part of Rubocop update.
1. Split JS bundle into chunks.
 
#### Before:
![Screen Shot 2019-04-23 at 2 49 39 PM](https://user-images.githubusercontent.com/7811733/56564037-6649d700-65d7-11e9-98ef-c2f57d25b987.png)


#### After:
![Screen Shot 2019-04-23 at 2 49 49 PM](https://user-images.githubusercontent.com/7811733/56564047-6a75f480-65d7-11e9-91b2-965961d52875.png)
