### PR TITLE
Precompile and cache assets in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,18 +19,21 @@ jobs:
     steps:
       - checkout
 
+      # JS bundle
       - restore_cache:
           key: yarn-{{ checksum "yarn.lock" }}
 
       - run:
           name: Install yarn dependencies
-          command: yarn install
+          command: yarn install --frozen-lockfile
 
       - save_cache:
           key: yarn-{{ checksum "yarn.lock" }}
           paths:
-            - ~/.yarn-cache
+            - node_modules
+            - ~/.cache/yarn
 
+      # Ruby gems bundle
       - restore_cache:
           key: bundle-{{ checksum "Gemfile.lock" }}
 
@@ -56,6 +59,11 @@ jobs:
           name: Set up app environment
           command: cp config/application.yml.example config/application.yml
 
+      # Assets precompilation requires ENV variables, so it must come after environment gets set up
+      - run:
+          name: Precompile assets and packs
+          command: bundle exec rake assets:precompile
+
       # Database setup
       - run:
           name: Set up database
@@ -80,7 +88,6 @@ jobs:
       # Save test results for timing analysis
       - store_test_results:
           path: test_results
-
   # deploy-master:
   #   machine:
   #     enabled: true
@@ -92,7 +99,6 @@ jobs:
   #         command: |
   #           git push https://heroku:${HEROKU_API_KEY}@git.heroku.com/${HEROKU_APP_NAME}-production.git master
   #           heroku run rake db:migrate --app ${HEROKU_APP_NAME}-production
-
   # deploy-staging:
   #   machine:
   #     enabled: true


### PR DESCRIPTION
This PR aims to improve spec stability and speed of test runs in CI.

#### Changes

- Add an extra step for asset precompilation before specs are run, so as to mirror the build process we have in production. Webpacker does lazy compilation of packs (compilation is not run before the test suite) so compilation happens when we hit the first system spec. As our JS codebase grows, compilation can take longer than the timeouts we have in place. We're not seeing these failures locally because you already have packs cache files in place from running webpack in development (see `tmp/cache/webpacker`). This may or may not be the sole reason for failing specs, but it definitely adds to the randomness of failures we've been seeing lately (variable compilation time + random order of specs). With this in place, no compilation happens during specs run (packs and their digests are fetched from cached folders) so they should be more predictable.
- Cache `node_modules` together with all yarn folders. This way fetching and linking packages (copying from global cache to project `node_modules` folder) becomes almost instantaneous, see the [last run](https://circleci.com/gh/Verumex/verumex/2980).
