### PR TITLE
Enforce Prettier formatting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,17 @@ jobs:
             - vendor/bundle
 
       - run:
+          name: Lint Ruby/Rails
+          command: |
+            bundle exec rubocop -L | \
+            circleci tests split --split-by=timings --timings-type=filename | \
+            xargs bundle exec rubocop
+
+      - run:
+          name: Lint Javascript
+          command: yarn lint-check
+
+      - run:
           name: Verify bundle security
           command: bundle exec bundle-audit check --update
 

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,13 @@
+{
+  "printWidth": 80,
+  "arrowParens": "avoid",
+  "trailingComma": "es5",
+  "overrides": [
+    {
+      "files": "*.{jsx,tsx}",
+      "options": {
+        "printWidth": 100
+      }
+    }
+  ]
+}

--- a/app/assets/javascripts/cable.js
+++ b/app/assets/javascripts/cable.js
@@ -9,5 +9,4 @@
   this.App || (this.App = {});
 
   App.cable = ActionCable.createConsumer();
-
-}).call(this);
+}.call(this));

--- a/app/assets/javascripts/google_analytics.js
+++ b/app/assets/javascripts/google_analytics.js
@@ -1,5 +1,10 @@
-$(document).on('turbolinks:load', function () {
-  if (typeof gtag === 'function' && typeof SETTINGS.google_analytics_id != "undefined") {
-    gtag('config', SETTINGS.google_analytics_id, { page_path: window.location.pathname });
+$(document).on("turbolinks:load", function() {
+  if (
+    typeof gtag === "function" &&
+    typeof SETTINGS.google_analytics_id != "undefined"
+  ) {
+    gtag("config", SETTINGS.google_analytics_id, {
+      page_path: window.location.pathname,
+    });
   }
 });

--- a/package.json
+++ b/package.json
@@ -5,6 +5,13 @@
     "node": ">=8.9.0",
     "yarn": ">=1.9.0"
   },
+  "config": {
+    "files": "app/javascript/**/*.{js,jsx,ts,tsx} app/assets/javascripts/**/*.{js,jsx,ts,tsx} lib/tasks/**/*.{js,jsx,ts,tsx}"
+  },
+  "scripts": {
+    "lint-check": "eslint --format codeframe $npm_package_config_files && prettier --list-different $npm_package_config_files",
+    "lint-write": "eslint --fix $npm_package_config_files && prettier --write $npm_package_config_files"
+  },
   "dependencies": {
     "@babel/preset-react": "^7.0.0",
     "@rails/webpacker": "^4",


### PR DESCRIPTION
#### Changes

1. Enforce 80 char Prettier print width for js/ts, 100 chars for jsx/tsx files
1. Two handy yarn commands: `yarn lint-check` to check that code has been linted and prettified, and `yarn lint-write` for a quick way to fix all violations. `yarn lint-check` is run in CI to prevent any unformatted code from sneaking through.
1. Better formatting of ESlint errors in CI so it's immediately clear what's wrong
1. Fix any style offenses

@hiattp in VmX this will need one run of `yarn lint-write` and a push to development to start with a clean slate.

There are ways to make the setup smarter (e.g. pre-commit, pre-push hooks, linting staged files etc) but I think this is a good start we can iterate on later.