### PR TITLE
Force using node version ^12.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "rails_new",
   "private": true,
   "engines": {
-    "node": ">=8.9.0",
+    "node": "^12.4.0",
     "yarn": ">=1.9.0"
   },
   "config": {


### PR DESCRIPTION
Set node version in the engines key using semver `^12.4.0` (>=12.4.0 and <13.0.0).

When running `yarn`, if the installed node version doesn't meet the specified semver, Yarn will raise error.