### PR TITLE
remove concurrency default value

### DIFF
--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -1,6 +1,6 @@
 DATABASE_URL: 'postgres://localhost:5432/rails_new_development'
 HOST: 'http://localhost:3000'
-RAILS_MAX_THREADS: '1'
+RAILS_MAX_THREADS: '5'
 WEB_CONCURRENCY: '1'
 REDIS_URL: 'redis://localhost:6379'
 RAILS_SYSTEM_TESTING_SCREENSHOT: 'inline'

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -5,7 +5,6 @@
 # pick it up automatically.
 ---
 :verbose: false
-:concurrency: 5
 
 # Set timeout to 8 on Heroku, longer if you manage your own systems.
 :timeout: 8


### PR DESCRIPTION
Remove the default to allow concurrency to be dictated by `RAILS_MAX_THREADS` per [this](https://gist.github.com/nateberkopec/2d1fcf77dc61e747438252e3895badf0)