### PR TITLE
Do not collect performance stats in Airbrake

### DIFF
--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -52,6 +52,9 @@ Airbrake.configure do |c|
   # Alternatively, you can integrate with Rails' filter_parameters.
   # Read more: https://goo.gl/gqQ1xS
   c.blacklist_keys = Rails.application.config.filter_parameters
+
+  # Use APM tools to monitor performance instead
+  c.performance_stats = false
 end
 
 # A filter that collects request body information. Enable it if you are sure you


### PR DESCRIPTION
In a typical action this allocates quite a lot:

![Screen Shot 2019-08-02 at 3 45 52 PM](https://user-images.githubusercontent.com/7811733/62357128-a278c600-b53c-11e9-97e3-411be048b2af.png)

In the picture above, it's also directly responsible for most of allocation in `railties` with all the backtrace formatting it does. E.g in `api/v1/properties/totals` we can eliminate all the highlighted allocations which is a pretty great easy win:

![airbrake](https://user-images.githubusercontent.com/7811733/62357714-dc969780-b53d-11e9-86a5-b4ebd44d0c50.png)

Edit: same action after turning off the setting:

![airbrake](https://user-images.githubusercontent.com/7811733/62366849-343efe00-b552-11e9-90b0-95a7a4d838c3.gif)

61% reduction 🎉 

I think a) we're not using these stats and b) other tools are better-suited for performance monitoring.