### PR TITLE
Make screenshots of failed tests available under Artifacts tab

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,11 @@ jobs:
       # Save test results for timing analysis
       - store_test_results:
           path: test_results
+
+      # Make screenshots of failed tests available under Artifacts tab
+      - store_artifacts:
+          path: tmp/screenshots
+
   # deploy-master:
   #   machine:
   #     image: circleci/classic:latest


### PR DESCRIPTION
Conveniently stores screenshots for debugging:

![Screen Shot 2019-08-28 at 6 00 15 PM](https://user-images.githubusercontent.com/7811733/63850336-0072bf00-c9be-11e9-8ed0-f6ef36077999.png)

Screenshots are currently broken (blank white image) in Rails 6 and current version of `rspec-rails`. This is [fixed](https://github.com/rspec/rspec-rails/issues/2153) in v4 which should come out soon.