### PR TITLE
Update Target Ruby & Rails version in Rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,8 +4,8 @@ require:
   - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 2.4
-  TargetRailsVersion: 5.1
+  TargetRubyVersion: 2.6
+  TargetRailsVersion: 6.0
   Exclude:
     - 'db/**/*'
     - 'bin/*'


### PR DESCRIPTION
Updates target Ruby and Rails version to reflect the current setup of _Ruby 2.6_ & _Rails 6_.