### PR TITLE
Upgrade and lock bundler version in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,12 @@ jobs:
             - ~/.cache/yarn
 
       # Ruby gems bundle
+      - run:
+          name: Configure Bundler
+          command: |
+            BUNDLER_VERSION=$(cat Gemfile.lock | tail -1 | tr -d " ")
+            gem install bundler -v ${BUNDLER_VERSION}
+
       - restore_cache:
           key: bundle-{{ checksum "Gemfile.lock" }}
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -419,4 +419,4 @@ RUBY VERSION
    ruby 2.6.5p114
 
 BUNDLED WITH
-   1.17.3
+   2.0.2


### PR DESCRIPTION
Updates:

1. Use Bundler 2. It's faster and [supported](https://devcenter.heroku.com/articles/ruby-support#libraries) on Heroku. Matches the exact version Heroku will use.
2. Use the same version in CI as defined in the lockfile. If the versions differ and the feature branch adds a new dependency,  Circle will always run the full install, wasting time. This is because lockfile before and after will differ in the last line specifying bundle version. Hence, checksums differ so cache restore step looks for a different cache key than we use in save cache step.