### PR TITLE
Upgrade rspec-rails to 4.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -127,7 +127,7 @@ group :test do
   # Easy installation and use of chromedriver (and others) to run system tests
   # with Chrome
   gem 'factory_bot_rails'
-  gem 'rspec-rails', '~> 3.7'
+  gem 'rspec-rails'
   # CircleCI test metadata collection
   gem 'rspec_junit_formatter'
   gem 'selenium-webdriver'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -240,20 +240,20 @@ GEM
     rexml (3.2.4)
     rspec-core (3.9.2)
       rspec-support (~> 3.9.3)
-    rspec-expectations (3.9.1)
+    rspec-expectations (3.9.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-mocks (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
-    rspec-rails (3.9.1)
-      actionpack (>= 3.0)
-      activesupport (>= 3.0)
-      railties (>= 3.0)
-      rspec-core (~> 3.9.0)
-      rspec-expectations (~> 3.9.0)
-      rspec-mocks (~> 3.9.0)
-      rspec-support (~> 3.9.0)
+    rspec-rails (4.0.0)
+      actionpack (>= 4.2)
+      activesupport (>= 4.2)
+      railties (>= 4.2)
+      rspec-core (~> 3.9)
+      rspec-expectations (~> 3.9)
+      rspec-mocks (~> 3.9)
+      rspec-support (~> 3.9)
     rspec-support (3.9.3)
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
@@ -394,7 +394,7 @@ DEPENDENCIES
   rack-timeout
   rails (~> 6.0.0)
   react-rails
-  rspec-rails (~> 3.7)
+  rspec-rails
   rspec_junit_formatter
   rubocop
   rubocop-performance


### PR DESCRIPTION
This makes `rspec` Rails 6 compatible, so failed screenshots are working again.

Before:
![Screen Shot 2020-05-12 at 7 05 48 PM](https://user-images.githubusercontent.com/7811733/81688289-b36b4600-9483-11ea-8023-497a169a9afb.png)

After:
![Screen Shot 2020-05-12 at 7 05 37 PM](https://user-images.githubusercontent.com/7811733/81688344-b9f9bd80-9483-11ea-91f7-d4e0b645a130.png)

These were previously saved as blank images, now they work as expected.