### PR TITLE
Run rubocop in parallel in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,9 +55,9 @@ jobs:
       - run:
           name: Lint Ruby/Rails
           command: |
-            bundle exec rubocop -L | \
-            circleci tests split --split-by=timings --timings-type=filename | \
-            xargs bundle exec rubocop
+            bundle exec rubocop --list-target-files | \
+            circleci tests split | \
+            xargs bundle exec rubocop --parallel
 
       - run:
           name: Lint JavaScript

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,6 +30,9 @@ Layout/DotPosition:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#consistent-multi-line-chains'
   EnforcedStyle: leading
 
+Layout/EmptyLinesAroundAttributeAccessor:
+  Enabled: true
+
 Layout/ExtraSpacing:
   Description: 'Do not use unnecessary spacing.'
   Enabled: true
@@ -613,6 +616,9 @@ Style/SingleLineMethods:
 Style/SignalException:
   Description: 'Checks for proper usage of fail and raise.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#fail-method'
+  Enabled: true
+
+Style/SlicingWithRange:
   Enabled: true
 
 Style/SpecialGlobalVars:

--- a/app/forms/application_form.rb
+++ b/app/forms/application_form.rb
@@ -20,6 +20,7 @@ class ApplicationForm
     def attributes(*attributes)
       @form_attributes = attributes.map do |attribute|
         attr_accessor attribute
+
         attribute.to_s
       end
     end


### PR DESCRIPTION
This reduces the time to lint ruby files in CI from 20-50s to ~10s. Part of the reason is splitting the run between available CPUs, part of it is (I believe) not looking up timings which don't exist. Rubocop doesn't output timings so simple split by filenames will do just fine.

Rubocop also does caching so that it only lints files that changed but the difference it made was just one second so that didn't justify steps to restore and save cache.