### PR TITLE
Cache precompiled assets in CI, use PG 12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,10 +85,23 @@ jobs:
           name: Set up app environment
           command: cp config/application.yml.example config/application.yml
 
+      - restore_cache:
+          keys:
+            - assets-{{ .Branch }}
+            - assets-development
+
       # Assets precompilation requires ENV variables, so it must come after environment gets set up
       - run:
           name: Precompile assets and packs
           command: bundle exec rake assets:precompile
+
+      - save_cache:
+          key: assets-{{ .Branch }}-{{ epoch }}
+          paths:
+            - public/assets
+            - public/packs-test
+            - tmp/cache/assets/sprockets
+            - tmp/cache/webpacker
 
       # Database setup
       - run:


### PR DESCRIPTION
**Changes**

1. Update Postgres to v12. This is now the [default](https://devcenter.heroku.com/articles/heroku-postgresql#version-support) on Heroku.
1. Cache precompiled assets. This shaves a significant time off of a typical test run (1-2 minutes) 🎉

The caching strategy is as follows:

1. Always save a cache for every test run. This is very cheap to do (~1s, they're 10MB or so).
1. When restoring cache, look for the latest cache from the same branch. If not found, default to the cache from development.

This covers both assets (JS and CSS) and packs. It's a safe approach since Sprockets and Webpacker use file digests. If they're not found in the cache (any file changed), the compilation will be done from scratch.