### PR TITLE
Fix validators_on not returning resource validators

### DIFF
--- a/app/forms/application_form.rb
+++ b/app/forms/application_form.rb
@@ -47,6 +47,12 @@ class ApplicationForm
         end
       end
     end
+
+    # Returns a full set of form object and resource validators.
+    # This is used by form libraries, such as simple_form.
+    def validators_on(*attributes)
+      super + resource_class.validators_on(*attributes)
+    end
   end
 
   # The underlying model wrapped by the form.

--- a/spec/forms/application_form_spec.rb
+++ b/spec/forms/application_form_spec.rb
@@ -24,6 +24,12 @@ describe ApplicationForm do
       it 'uses an explicitly specified model name' do
         expect(SignupForm.resource_class).to eq TestAccount
       end
+
+      it 'correctly returns all validators' do
+        # Validated automatically by Devise.
+        expect(SignupForm.validators_on(:email).size).to be > 0
+        expect(SignupForm.validators_on(:name).size).to be > 0
+      end
     end
 
     describe '.model_name' do


### PR DESCRIPTION
[`validators_on`](https://github.com/rails/rails/blob/8642c564dab37366c2ca8950b428d1aec84eb10d/activemodel/lib/active_model/validations.rb#L254) as defined in Rails for reference.

Closes #165