### PR TITLE
Fix source maps in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -56,11 +56,6 @@ Rails.application.configure do
   # Highlight code that triggered database queries in logs.
   config.active_record.verbose_query_logs = true
 
-  # Debug mode disables concatenation and preprocessing of assets.
-  # This option may cause significant delays in view rendering with a large
-  # number of complex assets.
-  config.assets.debug = true
-
   # Suppress logger output for asset requests.
   config.assets.quiet = true
 


### PR DESCRIPTION
### Before

![before](http://g.recordit.co/TzkYVQChMP.gif)

### After

![after](http://g.recordit.co/RDciOg6KB1.gif)

Historically, the debug option made it possible to serve individual files in development. `sprockets` 4 added source maps in development so this is no longer necessary. In fact, it broke source locations for VmX so disabling it is all that was necessary.

Apart from fixing the issue, this also improves compilation speed 🚀 

>By using source maps in development instead of having branching behavior, we bring development/production parity and make the experience of debugging assets generated by Sprockets similar to those generated by JS tooling. 