### PR TITLE
Use jsonapi-serializer instead of fast_jsonapi

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ gem 'pundit'
 gem 'devise', '~> 4.7.0'
 
 # API serialization
-gem 'fast_jsonapi'
+gem 'jsonapi-serializer'
 
 # App configuration
 gem 'figaro'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,8 +113,6 @@ GEM
       railties (>= 4.2.0)
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
-    fast_jsonapi (1.5)
-      activesupport (>= 4.2)
     ffi (1.13.1)
     figaro (1.2.0)
       thor (>= 0.14.0, < 2)
@@ -126,6 +124,8 @@ GEM
       rack (>= 1.4.5)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
+    jsonapi-serializer (2.0.0)
+      activesupport (>= 4.2)
     launchy (2.5.0)
       addressable (~> 2.7)
     letter_opener (1.7.0)
@@ -374,10 +374,10 @@ DEPENDENCIES
   capybara
   devise (~> 4.7.0)
   factory_bot_rails
-  fast_jsonapi
   figaro
   foreman
   heroku-deflater
+  jsonapi-serializer
   letter_opener
   listen (>= 3.0.5, < 3.2)
   lograge


### PR DESCRIPTION
`fast_jsonapi` has been inactive for more than a year with issues piling up, see [this issue](https://github.com/Netflix/fast_jsonapi/issues/462). `jsonapi-serializer` is a fork with active development with minor API changes.

When migrating:
1. `include JSONAPI::Serializer` in the serializer, instead of `include FastJsonapi::ObjectSerializer`
1. replace `.serialized_json` with `.serializable_hash.to_json`